### PR TITLE
Table 컴포넌트에 columnTemplate props 추가, 각 열의 비율을 정한 경우 스토리 작성

### DIFF
--- a/src/lib/Table/Table.stories.tsx
+++ b/src/lib/Table/Table.stories.tsx
@@ -34,6 +34,16 @@ export const Default: Story = {
   ),
 };
 
+export const WithColumnTemplate: Story = {
+  render: () => (
+    <Table<Member>
+      columns={MEMBER_LIST_MANY_COLUMNS}
+      rows={MEMBER_LIST_MANY_COLUMNS_LIST}
+      columnTemplate='1fr 2fr 1fr 1fr 1fr 1fr 1fr 1fr'
+    />
+  ),
+};
+
 export const Dense: Story = {
   render: () => (
     <Table<Member> columns={MEMBER_LIST_COLUMN} rows={MEMBER_LIST} dense />

--- a/src/lib/Table/index.tsx
+++ b/src/lib/Table/index.tsx
@@ -4,18 +4,20 @@ interface TableProps<T> {
   columns: string[];
   rows: T;
   dense?: boolean;
+  columnTemplate?: string;
 }
 
 export default function Table<T extends object>({
   columns,
   rows,
   dense = false,
+  columnTemplate,
 }: TableProps<T[]>) {
   return (
     <S.Wrapper>
       <S.Table>
         <S.THead>
-          <S.Tr $childLength={columns.length}>
+          <S.Tr $columnTemplate={columnTemplate} $childLength={columns.length}>
             {columns.map((column) => (
               <S.Th>{column}</S.Th>
             ))}
@@ -27,7 +29,11 @@ export default function Table<T extends object>({
           ) : (
             <>
               {rows.map((row, index) => (
-                <S.Tr key={index} $childLength={columns.length}>
+                <S.Tr
+                  key={index}
+                  $columnTemplate={columnTemplate}
+                  $childLength={columns.length}
+                >
                   {Object.entries(row).map(([key, value], index) => (
                     <S.Td key={`${key}${index}`} $dense={dense}>
                       {value}

--- a/src/lib/Table/mockData.tsx
+++ b/src/lib/Table/mockData.tsx
@@ -130,7 +130,7 @@ export const MEMBER_LIST_MANY_COLUMNS_LIST: Member[] = [
   },
   {
     id: 15,
-    name: 'Nero',
+    name: 'Very Long Long Long Long Long Name',
     age: 27,
     gender: 'FEMALE',
     level: 'gold',

--- a/src/lib/Table/style.ts
+++ b/src/lib/Table/style.ts
@@ -1,4 +1,5 @@
 import { styled } from 'styled-components';
+import { theme } from '../style/theme';
 
 export const Wrapper = styled.section`
   @media (max-width: 679px) {
@@ -30,10 +31,11 @@ export const THead = styled.thead`
   background-color: #dcf0fa;
 `;
 
-export const Tr = styled.tr<{ $childLength: number }>`
+export const Tr = styled.tr<{ $columnTemplate?: string; $childLength: number }>`
   display: grid;
-  grid-template-columns: ${(props) => `repeat(${props.$childLength}, 1fr)`};
-  grid-gap: 10px;
+  grid-template-columns: ${({ $columnTemplate, $childLength }) =>
+    $columnTemplate ? $columnTemplate : `repeat(${$childLength}, 1fr)`};
+  gap: 10px;
 
   width: 100%;
   border-bottom: 1px solid #e2e2e2;
@@ -45,6 +47,9 @@ export const Tr = styled.tr<{ $childLength: number }>`
 `;
 
 export const Th = styled.th`
+  display: flex;
+  justify-content: start;
+
   padding: 10px 0;
 
   font: var(--text-caption);
@@ -52,7 +57,14 @@ export const Th = styled.th`
 `;
 
 export const Td = styled.td<{ $dense: boolean }>`
+  display: flex;
+  justify-content: start;
+
   padding: ${(props) => (props.$dense ? '5px 0' : '10px 0')};
+
+  @media (max-width: ${theme.breakpoint.sm}) {
+    font-size: 13px;
+  }
 `;
 
 export const EmptyData = styled.p`


### PR DESCRIPTION
## 🔥 연관 이슈

close: #8

## 📝 작업 요약
Table 컴포넌트에 columnTemplate props 추가, 각 열의 비율을 정한 경우 스토리 작성

## ⏰ 소요 시간
40분

## 🔎 작업 상세 설명
* Table 컴포넌트에 columnTemplate props를 추가하여 각 열의 비율을 사용자가 조절 가능하도록 했습니다. 
* Td 안의 자식 요소는 중앙 정렬 대신 왼쪽 정렬이 되도록 변경하였습니다.

