### PR TITLE
ResponsiveFlex 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "votogether-design-system",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "votogether-design-system",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "votogether-design-system",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "votogether-design-system",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "votogether-design-system",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "votogether-design-system",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "votogether-design-system",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "votogether-design-system",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "votogether-design-system",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "votogether-design-system",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "votogether-design-system",
   "private": false,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "main": "dist/index.umd.cjs",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "votogether-design-system",
   "private": false,
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "main": "dist/index.umd.cjs",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "votogether-design-system",
   "private": false,
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "main": "dist/index.umd.cjs",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "votogether-design-system",
   "private": false,
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "main": "dist/index.umd.cjs",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "votogether-design-system",
   "private": false,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "main": "dist/index.umd.cjs",
   "module": "dist/index.js",

--- a/src/lib/ResponsiveFlex/ResponsiveFlex.stories.tsx
+++ b/src/lib/ResponsiveFlex/ResponsiveFlex.stories.tsx
@@ -62,7 +62,7 @@ export const LargeMarginTwentyPixel: Story = {
     <ResponsiveFlex
       breakpoint={theme.breakpoint.sm}
       ratio={70}
-      lgmargin={'20px'}
+      $lgMargin={'20px'}
     >
       <FirstBox>FirstBox</FirstBox>
       <SecondBox>SecondBox</SecondBox>
@@ -75,7 +75,7 @@ export const LargePaddingTwentyPixel: Story = {
     <ResponsiveFlex
       breakpoint={theme.breakpoint.sm}
       ratio={70}
-      lgpadding={'20px'}
+      $lgPadding={'20px'}
     >
       <FirstBox>FirstBox</FirstBox>
       <SecondBox>SecondBox</SecondBox>
@@ -88,7 +88,7 @@ export const SmallMarginTwentyPixel: Story = {
     <ResponsiveFlex
       breakpoint={theme.breakpoint.sm}
       ratio={70}
-      smmargin={'20px'}
+      $smMargin={'20px'}
     >
       <FirstBox>FirstBox</FirstBox>
       <SecondBox>SecondBox</SecondBox>
@@ -101,7 +101,7 @@ export const SmallPaddingTwentyPixel: Story = {
     <ResponsiveFlex
       breakpoint={theme.breakpoint.sm}
       ratio={70}
-      smpadding={'20px'}
+      $smPadding={'20px'}
     >
       <FirstBox>FirstBox</FirstBox>
       <SecondBox>SecondBox</SecondBox>

--- a/src/lib/ResponsiveFlex/ResponsiveFlex.stories.tsx
+++ b/src/lib/ResponsiveFlex/ResponsiveFlex.stories.tsx
@@ -7,6 +7,7 @@ import ResponsiveFlex from '.';
 
 const meta: Meta<typeof ResponsiveFlex> = {
   component: ResponsiveFlex,
+  tags: ['autodocs'],
 };
 
 export default meta;

--- a/src/lib/ResponsiveFlex/ResponsiveFlex.stories.tsx
+++ b/src/lib/ResponsiveFlex/ResponsiveFlex.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { theme } from '../style/theme';
+import styled from 'styled-components';
+
+import ResponsiveFlex from '.';
+
+const meta: Meta<typeof ResponsiveFlex> = {
+  component: ResponsiveFlex,
+};
+
+export default meta;
+type Story = StoryObj<typeof ResponsiveFlex>;
+
+const FirstBox = styled.div`
+  height: 100px;
+
+  border: 1px solid gray;
+  padding: 10px;
+
+  background-color: #b2a592;
+`;
+
+const SecondBox = styled.div`
+  height: 50px;
+
+  border: 1px solid gray;
+  padding: 10px;
+
+  background-color: #d5c8ae;
+`;
+
+export const Default: Story = {
+  render: () => (
+    <ResponsiveFlex breakpoint={theme.breakpoint.sm}>
+      <FirstBox>FirstBox</FirstBox>
+      <SecondBox>SecondBox</SecondBox>
+    </ResponsiveFlex>
+  ),
+};
+
+export const BreakpointTablet: Story = {
+  render: () => (
+    <ResponsiveFlex breakpoint={theme.breakpoint.md}>
+      <FirstBox>FirstBox</FirstBox>
+      <SecondBox>SecondBox</SecondBox>
+    </ResponsiveFlex>
+  ),
+};
+
+export const RatioForFirstBoxSeventy: Story = {
+  render: () => (
+    <ResponsiveFlex breakpoint={theme.breakpoint.sm} ratio={70}>
+      <FirstBox>FirstBox</FirstBox>
+      <SecondBox>SecondBox</SecondBox>
+    </ResponsiveFlex>
+  ),
+};
+
+export const LargeMarginTwentyPixel: Story = {
+  render: () => (
+    <ResponsiveFlex
+      breakpoint={theme.breakpoint.sm}
+      ratio={70}
+      lgmargin={'20px'}
+    >
+      <FirstBox>FirstBox</FirstBox>
+      <SecondBox>SecondBox</SecondBox>
+    </ResponsiveFlex>
+  ),
+};
+
+export const LargePaddingTwentyPixel: Story = {
+  render: () => (
+    <ResponsiveFlex
+      breakpoint={theme.breakpoint.sm}
+      ratio={70}
+      lgpadding={'20px'}
+    >
+      <FirstBox>FirstBox</FirstBox>
+      <SecondBox>SecondBox</SecondBox>
+    </ResponsiveFlex>
+  ),
+};
+
+export const SmallMarginTwentyPixel: Story = {
+  render: () => (
+    <ResponsiveFlex
+      breakpoint={theme.breakpoint.sm}
+      ratio={70}
+      smmargin={'20px'}
+    >
+      <FirstBox>FirstBox</FirstBox>
+      <SecondBox>SecondBox</SecondBox>
+    </ResponsiveFlex>
+  ),
+};
+
+export const SmallPaddingTwentyPixel: Story = {
+  render: () => (
+    <ResponsiveFlex
+      breakpoint={theme.breakpoint.sm}
+      ratio={70}
+      smpadding={'20px'}
+    >
+      <FirstBox>FirstBox</FirstBox>
+      <SecondBox>SecondBox</SecondBox>
+    </ResponsiveFlex>
+  ),
+};

--- a/src/lib/ResponsiveFlex/index.tsx
+++ b/src/lib/ResponsiveFlex/index.tsx
@@ -1,0 +1,71 @@
+import { PropsWithChildren, ReactNode } from 'react';
+
+import { theme } from '../style/theme';
+import { StringPixel } from '../types';
+
+import * as S from './style';
+
+interface ResponsiveFlexProps extends PropsWithChildren {
+  /**
+   * breakpoint that arranges children from horizontal to vertical (min-width: breakpoint)
+   */
+  breakpoint: number;
+  /**
+   * gap between two children
+   */
+  gap?: StringPixel;
+  /**
+   * ratio of left-sided child(first index of children)
+   * unit is percent (ex. 40%)
+   * (if 70%, right-sided is automatically 30%)
+   */
+  ratio?: number;
+  /**
+   * margin of Flex when width is less than breakpoint
+   */
+  smmargin?: StringPixel;
+  /**
+   * padding of Flex when width is less than breakpoint
+   */
+  smpadding?: StringPixel;
+  /**
+   * margin of Flex when width is no less than breakpoint
+   */
+  lgmargin?: StringPixel;
+  /**
+   * padding of Flex when width is no less than breakpoint
+   */
+  lgpadding?: StringPixel;
+  /**
+   * children of Flex, The number of children should be 2
+   */
+  children: [ReactNode, ReactNode];
+}
+
+export default function ResponsiveFlex({
+  breakpoint = theme.breakpoint.sm,
+  gap = '10px',
+  ratio = 50,
+  smmargin = '10px',
+  smpadding = '10px',
+  lgmargin = '10px',
+  lgpadding = '10px',
+  children,
+}: ResponsiveFlexProps) {
+  if (children.length !== 2)
+    return <div>ResponsiveFlex component needs two children.</div>;
+
+  return (
+    <S.Wrapper
+      breakpoint={breakpoint}
+      gap={gap}
+      smmargin={smmargin}
+      smpadding={smpadding}
+      lgmargin={lgmargin}
+      lgpadding={lgpadding}
+    >
+      <S.FirstBox ratio={ratio}>{children[0]}</S.FirstBox>
+      <S.SecondBox ratio={100 - ratio}>{children[1]}</S.SecondBox>
+    </S.Wrapper>
+  );
+}

--- a/src/lib/ResponsiveFlex/index.tsx
+++ b/src/lib/ResponsiveFlex/index.tsx
@@ -23,19 +23,19 @@ interface ResponsiveFlexProps extends PropsWithChildren {
   /**
    * margin of Flex when width is less than breakpoint
    */
-  smmargin?: StringPixel;
+  $smMargin?: StringPixel;
   /**
    * padding of Flex when width is less than breakpoint
    */
-  smpadding?: StringPixel;
+  $smPadding?: StringPixel;
   /**
    * margin of Flex when width is no less than breakpoint
    */
-  lgmargin?: StringPixel;
+  $lgMargin?: StringPixel;
   /**
    * padding of Flex when width is no less than breakpoint
    */
-  lgpadding?: StringPixel;
+  $lgPadding?: StringPixel;
   /**
    * children of Flex, The number of children should be 2
    */
@@ -46,10 +46,10 @@ export default function ResponsiveFlex({
   breakpoint = theme.breakpoint.sm,
   gap = '10px',
   ratio = 50,
-  smmargin = '10px',
-  smpadding = '10px',
-  lgmargin = '10px',
-  lgpadding = '10px',
+  $smMargin = '10px',
+  $smPadding = '10px',
+  $lgMargin = '10px',
+  $lgPadding = '10px',
   children,
 }: ResponsiveFlexProps) {
   if (children.length !== 2)
@@ -59,10 +59,10 @@ export default function ResponsiveFlex({
     <S.Wrapper
       breakpoint={breakpoint}
       gap={gap}
-      smmargin={smmargin}
-      smpadding={smpadding}
-      lgmargin={lgmargin}
-      lgpadding={lgpadding}
+      $smMargin={$smMargin}
+      $smPadding={$smPadding}
+      $lgMargin={$lgMargin}
+      $lgPadding={$lgPadding}
     >
       <S.FirstBox ratio={ratio}>{children[0]}</S.FirstBox>
       <S.SecondBox ratio={100 - ratio}>{children[1]}</S.SecondBox>

--- a/src/lib/ResponsiveFlex/index.tsx
+++ b/src/lib/ResponsiveFlex/index.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren, ReactNode } from 'react';
 
 import { theme } from '../style/theme';
-import { StringPixel } from '../types';
+import { MarginPadding, StringPixel } from '../types';
 
 import * as S from './style';
 
@@ -9,11 +9,15 @@ interface ResponsiveFlexProps extends PropsWithChildren {
   /**
    * breakpoint that arranges children from horizontal to vertical (min-width: breakpoint)
    */
-  breakpoint: number;
+  breakpoint: StringPixel;
   /**
-   * gap between two children
+   * gap between two children when width is less than breakpoint
    */
-  gap?: StringPixel;
+  $smGap?: StringPixel;
+  /**
+   * gap between two children when width is no less than breakpoint
+   */
+  $lgGap?: StringPixel;
   /**
    * ratio of left-sided child(first index of children)
    * unit is percent (ex. 40%)
@@ -23,19 +27,27 @@ interface ResponsiveFlexProps extends PropsWithChildren {
   /**
    * margin of Flex when width is less than breakpoint
    */
-  $smMargin?: StringPixel;
+  $smMargin?: MarginPadding;
   /**
    * padding of Flex when width is less than breakpoint
    */
-  $smPadding?: StringPixel;
+  $smPadding?: MarginPadding;
   /**
    * margin of Flex when width is no less than breakpoint
    */
-  $lgMargin?: StringPixel;
+  $lgMargin?: MarginPadding;
   /**
    * padding of Flex when width is no less than breakpoint
    */
-  $lgPadding?: StringPixel;
+  $lgPadding?: MarginPadding;
+  /**
+   * justify-content of Flex
+   */
+  $justifyContent?: string;
+  /**
+   * align-items of Flex
+   */
+  $alignItems?: string;
   /**
    * children of Flex, The number of children should be 2
    */
@@ -44,12 +56,15 @@ interface ResponsiveFlexProps extends PropsWithChildren {
 
 export default function ResponsiveFlex({
   breakpoint = theme.breakpoint.sm,
-  gap = '10px',
+  $smGap = '10px',
+  $lgGap = '10px',
   ratio = 50,
   $smMargin = '10px',
   $smPadding = '10px',
   $lgMargin = '10px',
   $lgPadding = '10px',
+  $justifyContent = 'space-between',
+  $alignItems = 'center',
   children,
 }: ResponsiveFlexProps) {
   if (children.length !== 2)
@@ -58,14 +73,21 @@ export default function ResponsiveFlex({
   return (
     <S.Wrapper
       breakpoint={breakpoint}
-      gap={gap}
+      $smGap={$smGap}
+      $lgGap={$lgGap}
       $smMargin={$smMargin}
       $smPadding={$smPadding}
       $lgMargin={$lgMargin}
       $lgPadding={$lgPadding}
+      $justifyContent={$justifyContent}
+      $alignItems={$alignItems}
     >
-      <S.FirstBox ratio={ratio}>{children[0]}</S.FirstBox>
-      <S.SecondBox ratio={100 - ratio}>{children[1]}</S.SecondBox>
+      <S.FirstBox breakpoint={breakpoint} ratio={ratio}>
+        {children[0]}
+      </S.FirstBox>
+      <S.SecondBox breakpoint={breakpoint} ratio={100 - ratio}>
+        {children[1]}
+      </S.SecondBox>
     </S.Wrapper>
   );
 }

--- a/src/lib/ResponsiveFlex/style.ts
+++ b/src/lib/ResponsiveFlex/style.ts
@@ -1,20 +1,25 @@
 import { styled } from 'styled-components';
-import { theme } from '../style/theme';
+import { MarginPadding, StringPixel } from '../types';
 
 interface WrapperProps {
-  breakpoint: number;
-  gap: string;
-  $smMargin: string;
-  $smPadding: string;
-  $lgMargin: string;
-  $lgPadding: string;
+  breakpoint: StringPixel;
+  $smGap: StringPixel;
+  $lgGap: StringPixel;
+  $smMargin: MarginPadding;
+  $smPadding: MarginPadding;
+  $lgMargin: MarginPadding;
+  $lgPadding: MarginPadding;
+  $justifyContent: string;
+  $alignItems: string;
 }
 
 export const Wrapper = styled.div<WrapperProps>`
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: ${({ gap }) => gap};
+  justify-content: ${({ $justifyContent }) => $justifyContent};
+  align-items: ${({ $alignItems }) => $alignItems};
+
+  gap: ${({ $smGap }) => $smGap};
 
   width: 100%;
   height: 100%;
@@ -22,28 +27,34 @@ export const Wrapper = styled.div<WrapperProps>`
   margin: ${({ $smMargin }) => $smMargin};
   padding: ${({ $smPadding }) => $smPadding};
 
-  @media (min-width: ${theme.breakpoint.sm}) {
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  @media (min-width: ${({ breakpoint }) => breakpoint}) {
     flex-direction: row;
+    gap: ${({ $lgGap }) => $lgGap};
+
     margin: ${({ $lgMargin }) => $lgMargin};
     padding: ${({ $lgPadding }) => $lgPadding};
   }
 `;
 
-export const FirstBox = styled.div<{ ratio: number }>`
+export const FirstBox = styled.div<{ breakpoint: string; ratio: number }>`
   width: 100%;
   height: ${({ ratio }) => `${ratio}%`};
 
-  @media (min-width: ${theme.breakpoint.sm}) {
+  @media (min-width: ${({ breakpoint }) => breakpoint}) {
     width: ${({ ratio }) => `${ratio}%`};
     height: 100%;
   }
 `;
 
-export const SecondBox = styled.div<{ ratio: number }>`
+export const SecondBox = styled.div<{ breakpoint: string; ratio: number }>`
   width: 100%;
   height: ${({ ratio }) => `${ratio}%`};
 
-  @media (min-width: ${theme.breakpoint.sm}) {
+  @media (min-width: ${({ breakpoint }) => breakpoint}) {
     width: ${({ ratio }) => `${ratio}%`};
     height: 100%;
   }

--- a/src/lib/ResponsiveFlex/style.ts
+++ b/src/lib/ResponsiveFlex/style.ts
@@ -4,10 +4,10 @@ import { theme } from '../style/theme';
 interface WrapperProps {
   breakpoint: number;
   gap: string;
-  smmargin: string;
-  smpadding: string;
-  lgmargin: string;
-  lgpadding: string;
+  $smMargin: string;
+  $smPadding: string;
+  $lgMargin: string;
+  $lgPadding: string;
 }
 
 export const Wrapper = styled.div<WrapperProps>`
@@ -19,13 +19,13 @@ export const Wrapper = styled.div<WrapperProps>`
   width: 100%;
   height: 100%;
 
-  margin: ${({ smmargin }) => smmargin};
-  padding: ${({ smpadding }) => smpadding};
+  margin: ${({ $smMargin }) => $smMargin};
+  padding: ${({ $smPadding }) => $smPadding};
 
   @media (min-width: ${theme.breakpoint.sm}) {
     flex-direction: row;
-    margin: ${({ lgmargin }) => lgmargin};
-    padding: ${({ lgpadding }) => lgpadding};
+    margin: ${({ $lgMargin }) => $lgMargin};
+    padding: ${({ $lgPadding }) => $lgPadding};
   }
 `;
 

--- a/src/lib/ResponsiveFlex/style.ts
+++ b/src/lib/ResponsiveFlex/style.ts
@@ -1,0 +1,50 @@
+import { styled } from 'styled-components';
+import { theme } from '../style/theme';
+
+interface WrapperProps {
+  breakpoint: number;
+  gap: string;
+  smmargin: string;
+  smpadding: string;
+  lgmargin: string;
+  lgpadding: string;
+}
+
+export const Wrapper = styled.div<WrapperProps>`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: ${({ gap }) => gap};
+
+  width: 100%;
+  height: 100%;
+
+  margin: ${({ smmargin }) => smmargin};
+  padding: ${({ smpadding }) => smpadding};
+
+  @media (min-width: ${theme.breakpoint.sm}) {
+    flex-direction: row;
+    margin: ${({ lgmargin }) => lgmargin};
+    padding: ${({ lgpadding }) => lgpadding};
+  }
+`;
+
+export const FirstBox = styled.div<{ ratio: number }>`
+  width: 100%;
+  height: ${({ ratio }) => `${ratio}%`};
+
+  @media (min-width: ${theme.breakpoint.sm}) {
+    width: ${({ ratio }) => `${ratio}%`};
+    height: 100%;
+  }
+`;
+
+export const SecondBox = styled.div<{ ratio: number }>`
+  width: 100%;
+  height: ${({ ratio }) => `${ratio}%`};
+
+  @media (min-width: ${theme.breakpoint.sm}) {
+    width: ${({ ratio }) => `${ratio}%`};
+    height: 100%;
+  }
+`;

--- a/src/lib/ResponsiveFlex/style.ts
+++ b/src/lib/ResponsiveFlex/style.ts
@@ -27,9 +27,8 @@ export const Wrapper = styled.div<WrapperProps>`
   margin: ${({ $smMargin }) => $smMargin};
   padding: ${({ $smPadding }) => $smPadding};
 
-  &::-webkit-scrollbar {
-    display: none;
-  }
+  overflow-x: hidden;
+  overflow-y: hidden;
 
   @media (min-width: ${({ breakpoint }) => breakpoint}) {
     flex-direction: row;
@@ -37,6 +36,8 @@ export const Wrapper = styled.div<WrapperProps>`
 
     margin: ${({ $lgMargin }) => $lgMargin};
     padding: ${({ $lgPadding }) => $lgPadding};
+
+    overflow-y: auto;
   }
 `;
 

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -3,5 +3,6 @@ export { default as SquareButton } from './SquareButton';
 export { default as Skeleton } from './Skeleton';
 export { default as ToggleSwitch } from './ToggleSwitch';
 export { default as Table } from './Table';
+export { default as ResponsiveFlex } from './ResponsiveFlex';
 export { default as RoundButton } from './RoundButton';
 export { default as VDSProvider } from './VDSProvider';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,9 +1,12 @@
 export type Size = 'sm' | 'md' | 'lg';
 
-export type StringPercent = `${number}px`;
+export type StringPixel = `${number}px`;
 
-export type StringPixel =
+export type StringPercent = `${number}%`;
+
+export type MarginPadding =
   | `${number}px`
   | `${number}px ${number}px`
   | `${number}px ${number}px ${number}px`
-  | `${number}px ${number}px ${number}px ${number}px`;
+  | `${number}px ${number}px ${number}px ${number}px`
+  | 'auto';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,1 +1,9 @@
 export type Size = 'sm' | 'md' | 'lg';
+
+export type StringPercent = `${number}px`;
+
+export type StringPixel =
+  | `${number}px`
+  | `${number}px ${number}px`
+  | `${number}px ${number}px ${number}px`
+  | `${number}px ${number}px ${number}px ${number}px`;


### PR DESCRIPTION
## 🔥 연관 이슈

close: #13 

## 📝 작업 요약
ResponsiveFlex 컴포넌트 구현

## ⏰ 소요 시간
1.5시간

## 🔎 작업 상세 설명
해당 컴포넌트의 props 및 상세 설명은 아래와 같습니다.
```tsx
interface ResponsiveFlexProps extends PropsWithChildren {
  /**
   * breakpoint that arranges children from horizontal to vertical (min-width: breakpoint)
   */
  breakpoint: number;
  /**
   * gap between two children
   */
  gap?: StringPixel;
  /**
   * ratio of left-sided child(first index of children)
   * unit is percent (ex. 40%)
   * (if 70%, right-sided is automatically 30%)
   */
  ratio?: number;
  /**
   * margin of Flex when width is less than breakpoint
   */
  smmargin?: StringPixel;
  /**
   * padding of Flex when width is less than breakpoint
   */
  smpadding?: StringPixel;
  /**
   * margin of Flex when width is no less than breakpoint
   */
  lgmargin?: StringPixel;
  /**
   * padding of Flex when width is no less than breakpoint
   */
  lgpadding?: StringPixel;
  /**
   * children of Flex, The number of children should be 2
   */
  children: [ReactNode, ReactNode];
}
```
### 스크린샷
![responsive-flex-storybook](https://github.com/VoTogether-Design-System/design-system/assets/81199414/fba72bd0-7927-4b9f-957f-eebfa0834635)
